### PR TITLE
Reverting earlier change since bug was fixed in setuptools_scm 3.0.4

### DIFF
--- a/setuptools_scm_git_archive/__init__.py
+++ b/setuptools_scm_git_archive/__init__.py
@@ -12,7 +12,7 @@ def archival_to_version(data):
     trace('data', data)
     versions = tags_to_versions(tag_re.findall(data.get('ref-names', '')))
     if versions:
-        return meta(next(versions))
+        return meta(versions[0])
 
 
 def parse(root):


### PR DESCRIPTION
We had originally made a change in this repository to deal with a change in setuptools_scm version 3.0... but apparently they decided it was a bug, not a feature, and changed it back in 3.0.4 (see https://github.com/pypa/setuptools_scm/issues/286). So now, we're changing it back also. 



